### PR TITLE
Fix the retained parameter being ignored

### DIFF
--- a/espruino/modules/micro-mqtt.js
+++ b/espruino/modules/micro-mqtt.js
@@ -297,7 +297,7 @@ var Client = /** @class */ (function () {
         if (qos === void 0) { qos = 0 /* DefaultQos */; }
         if (retained === void 0) { retained = false; }
         if (this.sct) {
-            this.sct.write(Protocol.createPublish(topic, message, qos, true));
+            this.sct.write(Protocol.createPublish(topic, message, qos, retained));
         }
     };
     // Subscribe to topic

--- a/src/module/micro-mqtt.ts
+++ b/src/module/micro-mqtt.ts
@@ -326,7 +326,7 @@ export class Client {
     // Publish a message
     public publish(topic: string, message: string, qos: number = Constants.DefaultQos, retained: boolean = false): void {
         if (this.sct) {
-            this.sct.write(Protocol.createPublish(topic, message, qos, true));
+            this.sct.write(Protocol.createPublish(topic, message, qos, retained));
         }
     }
 

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -505,6 +505,7 @@ describe('The MQTT client', () => {
                 socket.sentPackages.should.have.lengthOf(1);
                 const packet: PublishPacketVerifier = new PublishPacketVerifier(socket.sentPackages[0]);
                 packet.shouldHaveQoS0();
+                packet.shouldNotBeRetained();
             });
         });
 
@@ -542,6 +543,25 @@ describe('The MQTT client', () => {
                 const packet: PublishPacketVerifier = new PublishPacketVerifier(socket.sentPackages[0]);
                 packet.shouldHaveQoS1();
                 packet.shouldBeRetained();
+            });
+        });
+
+        describe('with QoS 1, not retained.', () => {
+            beforeEach(() => {
+                socket = new MockSocket();
+
+                subject = new MqttClientTestSubclassBuilder()
+                    .whichIsConnectedOn(new MockNet(socket))
+                    .build();
+
+                subject.publish('some/topic', 'some-message', 1, false);
+            });
+
+            it('it should send a Publish packet with QoS 1, not retained.', () => {
+                socket.sentPackages.should.have.lengthOf(1);
+                const packet: PublishPacketVerifier = new PublishPacketVerifier(socket.sentPackages[0]);
+                packet.shouldHaveQoS1();
+                packet.shouldNotBeRetained();
             });
         });
     });

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -524,6 +524,7 @@ describe('The MQTT client', () => {
                 socket.sentPackages.should.have.lengthOf(1);
                 const packet: PublishPacketVerifier = new PublishPacketVerifier(socket.sentPackages[0]);
                 packet.shouldHaveQoS1();
+                packet.shouldNotBeRetained();
             });
         });
 


### PR DESCRIPTION
This fixes the issue #261. The publish function now uses the retained parameter as expected. 
The updated .js updated file also has been included.
The reason this problem wasn't detected during the test is because what is being tested is the 'Protocol' module, and this module is fine, the bug was in the 'Client' class publish method.